### PR TITLE
Add draw-all monster ability button

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -177,6 +177,20 @@
     cursor:                     pointer;
 }
 
+.draw-all.button
+{
+    position:                   absolute;
+    right:                      66%;
+    bottom:                     10px;
+    width:                      20%;
+    height:                     20%;
+    background-repeat:          no-repeat;
+    background-position:        center center;
+    background-size:            50%;
+    background-image:           url(images/draw-all.svg);
+    cursor:                     pointer;
+}
+
 .card-container.modifier
 {
     width:                      70%;

--- a/images/draw-all.svg
+++ b/images/draw-all.svg
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="157.69427mm"
+   height="159.47569mm"
+   viewBox="0 0 157.69427 159.4757"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r15371"
+   sodipodi:docname="draw-all.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.98994949"
+     inkscape:cx="131.292"
+     inkscape:cy="217.09241"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="2560"
+     inkscape:window-height="1537"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-16.557151,-18.522898)">
+    <rect
+       style="fill:#000000;stroke:#ffffff;stroke-width:8.86499977;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12"
+       width="93.544334"
+       height="134.16931"
+       x="10.451936"
+       y="46.563324"
+       ry="9.3544331"
+       transform="rotate(-11.257879)" />
+    <rect
+       style="fill:#000000;stroke:#ffffff;stroke-width:8.66499996;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12-8"
+       width="93.544342"
+       height="134.16931"
+       x="80.289528"
+       y="11.877546"
+       ry="9.3544331"
+       transform="rotate(7.139758)" />
+    <rect
+       style="fill:#000000;stroke:#ffffff;stroke-width:8.66499996;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12-9"
+       width="93.544342"
+       height="134.16931"
+       x="140.289528"
+       y="-22.122454"
+       ry="9.3544331"
+       transform="rotate(25)" />
+  </g>
+</svg>

--- a/logic.js
+++ b/logic.js
@@ -601,6 +601,16 @@ function double_draw(deck) {
   deck.advantage_to_clean = true;
 }
 
+function draw_all_ability_cards() {
+  var drawn = {};
+  visible_ability_decks.forEach(function (deck) {
+    if (!drawn[deck.class]) {
+      draw_ability_card(deck);
+      drawn[deck.class] = true;
+    }
+  });
+}
+
 function load_modifier_deck() {
   var deck = {
     name: "Monster modifier deck",
@@ -1068,8 +1078,14 @@ function add_modifier_deck(container, deck, preserve_discards) {
   draw_two_button.onclick = double_draw.bind(null, modifier_deck);
   draw_two_button.title = "Click to draw two cards";
 
+  var draw_all_button = document.createElement("div");
+  draw_all_button.className = "button draw-all";
+  draw_all_button.onclick = draw_all_ability_cards;
+  draw_all_button.title = "Click to draw all monster cards";
+
   deck_column.appendChild(deck_space);
   deck_column.appendChild(draw_two_button);
+  deck_column.appendChild(draw_all_button);
   deck_column.appendChild(end_round_div);
 
   modifier_container.appendChild(deck_column);


### PR DESCRIPTION
## Summary
- implement `draw_all_ability_cards` that draws for every visible monster deck
- add button to trigger it next to existing draw-two and shuffle actions
- create draw-all icon and styling

## Testing
- `bash gen-manifest.sh`

------
https://chatgpt.com/codex/tasks/task_e_68713825b9ac8323927f461aac51a629