### PR TITLE
Add shuffle animation for decks

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -556,6 +556,35 @@ img[src="images/shuffle.svg"]
     height:                     1.25em;
 }
 
+@keyframes shuffle-container
+{
+    0%   { transform: translateX(0) rotate(0deg); }
+    20%  { transform: translateX(-8%) rotate(-5deg); }
+    40%  { transform: translateX(8%) rotate(5deg); }
+    60%  { transform: translateX(-8%) rotate(-5deg); }
+    80%  { transform: translateX(8%) rotate(5deg); }
+    100% { transform: translateX(0) rotate(0deg); }
+}
+
+@-webkit-keyframes shuffle-container
+{
+    0%   { -webkit-transform: translateX(0) rotate(0deg); }
+    20%  { -webkit-transform: translateX(-8%) rotate(-5deg); }
+    40%  { -webkit-transform: translateX(8%) rotate(5deg); }
+    60%  { -webkit-transform: translateX(-8%) rotate(-5deg); }
+    80%  { -webkit-transform: translateX(8%) rotate(5deg); }
+    100% { -webkit-transform: translateX(0) rotate(0deg); }
+}
+
+.card-container.shuffle-animation
+{
+    -webkit-animation-name:     shuffle-container;
+    -webkit-animation-duration: 0.6s;
+
+    animation-name:             shuffle-container;
+    animation-duration:         0.6s;
+}
+
 .card::selection
 {
     color:                      rgba(0, 0, 0, 0);
@@ -577,6 +606,11 @@ img[src="images/shuffle.svg"]
 body.no-animation .card {
     -webkit-transition: none !important;
     transition: none !important;
+    -webkit-animation: none !important;
+    animation: none !important;
+}
+
+body.no-animation .card-container.shuffle-animation {
     -webkit-animation: none !important;
     animation: none !important;
 }


### PR DESCRIPTION
## Summary
- animate deck shuffling
- disable new animation with the animations toggle
- show shuffle before drawing when using Draw All

## Testing
- `./gen-manifest.sh`

------
https://chatgpt.com/codex/tasks/task_e_68713fea738c8323ab8734661ff7de68