### PR TITLE
Implement adaptive layout for monster stats

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -1304,6 +1304,10 @@ function create_stat_block(deck) {
     });
   }
 
+  if (grid.childElementCount > 4) {
+    grid.classList.add("three-cols");
+  }
+
   block.appendChild(grid);
 
   return block;

--- a/style.css
+++ b/style.css
@@ -258,7 +258,22 @@ li.currentdeck a:hover {
     justify-items: center;
 }
 
-/* When using the flexbox fallback each stat cell should take half the width */
+/* For monsters with many stats use a 3 column layout */
+.monster-stat-block .stats-grid.three-cols {
+    grid-template-columns: auto auto auto;
+}
+
+/* Flexbox fallback for 3 column layout */
+.monster-stat-block .stats-grid.three-cols > div {
+    -webkit-box-flex: 0;
+    -ms-flex: 0 0 33%;
+    flex: 0 0 33%;
+}
+
+
+/* When using the flexbox fallback each stat cell should take half the width
+ * (or one third in the three column layout)
+ */
 .monster-stat-block .stats-grid > div {
     -webkit-box-flex: 0;
     -ms-flex: 0 0 50%;


### PR DESCRIPTION
## Summary
- add three column styling for monster stat grids
- add flexbox fallback rules for three-column layout
- detect stat count in logic.js and add `three-cols` class when a monster has more than four stats

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68786ab92a348323a6c34e57b5355bde