### PR TITLE
Ensure monster stats stay on a single row

### DIFF
--- a/style.css
+++ b/style.css
@@ -211,7 +211,7 @@ li.currentdeck a:hover {
 #monster-stats-container {
     flex-basis: 100%;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
     margin: 0.5em 0;
     color: white;
@@ -287,8 +287,15 @@ li.currentdeck a:hover {
     margin: 0.3em;
     text-align: center;
     font-size: 1.2rem;
+    flex: 1 1 0;
+    min-width: 0;
 }
 
 .monster-stat-block .elite-color {
     color: gold;
+}
+
+.monster-stat-block > div:first-child {
+    white-space: normal;
+    word-break: break-word;
 }


### PR DESCRIPTION
## Summary
- prevent wrapping in the monster stats container so all cards appear in one row
- allow cards to shrink evenly and wrap monster names when needed

## Testing
- `bash gen-manifest.sh`

------
https://chatgpt.com/codex/tasks/task_e_687930b3d4408323b8b0ce2b0f2ad4ee