### PR TITLE
Add immunities and notes to monster stat cards

### DIFF
--- a/logic.js
+++ b/logic.js
@@ -1327,6 +1327,21 @@ function create_stat_block(deck) {
 
   block.appendChild(grid);
 
+  if (deck.immunities && deck.immunities.length) {
+    var imm = document.createElement("div");
+    imm.className = "small";
+    imm.innerHTML =
+      "Immunities: " + deck.immunities.map(expand_macro).join(", ");
+    block.appendChild(imm);
+  }
+
+  if (deck.notes && deck.notes.trim() !== "") {
+    var note = document.createElement("div");
+    note.className = "small";
+    note.innerHTML = "Notes: " + deck.notes;
+    block.appendChild(note);
+  }
+
   return block;
 }
 function LevelSelector(text, inline) {


### PR DESCRIPTION
## Summary
- show monster immunities and notes in the monster stat cards when available

## Testing
- `node --check logic.js`

------
https://chatgpt.com/codex/tasks/task_e_68794febdd908323a9f176da93b653f1