### PR TITLE
Refactor modifier deck layout

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -49,6 +49,25 @@
     height:                     100%;
 }
 
+.modifier-deck-column-3
+{
+    float:                      right;
+    margin:                     0;
+    padding:                    0;
+    width:                      20%;
+    height:                     100%;
+
+    display:                    -webkit-flex;
+    -webkit-flex-direction:     column;
+    -webkit-flex-wrap:          wrap;
+    justify-content:            center;
+
+    display:                    flex;
+    flex-direction:             column;
+    flex-wrap:                  wrap;
+    justify-content:            center;
+}
+
 .counter-icon
 {
     position:                   relative;
@@ -116,12 +135,9 @@
     background-size:            50%;
     cursor:                     pointer;
 
-    position:                   absolute;
-    right:                      18%;
-    bottom:                     10px;
-    width:                      20%;
-    height:                     20%;
-    margin: 0;
+    width:                      100%;
+    height:                     22%;
+    margin:                     0.3em 0;
 }
 
 .shuffle.not-required
@@ -165,11 +181,9 @@
 
 .draw-two.button
 {
-    position:                   absolute;
-    right:                      42%;
-    bottom:                     10px;
-    width:                      20%;
-    height:                     20%;
+    width:                      100%;
+    height:                     22%;
+    margin:                     0.3em 0;
     background-repeat:          no-repeat;
     background-position:        center center;
     background-size:            50%;
@@ -179,11 +193,9 @@
 
 .draw-all.button
 {
-    position:                   absolute;
-    right:                      66%;
-    bottom:                     10px;
-    width:                      20%;
-    height:                     20%;
+    width:                      100%;
+    height:                     22%;
+    margin:                     0.3em 0;
     background-repeat:          no-repeat;
     background-position:        center center;
     background-size:            50%;

--- a/logic.js
+++ b/logic.js
@@ -1181,12 +1181,17 @@ function add_modifier_deck(container, deck, preserve_discards) {
   draw_all_button.title = "Draw all monster cards";
 
   deck_column.appendChild(deck_space);
-  deck_column.appendChild(draw_all_button);
-  deck_column.appendChild(draw_two_button);
-  deck_column.appendChild(end_round_div);
 
-  modifier_container.appendChild(deck_column);
+  var controls_column = document.createElement("div");
+  controls_column.className = "modifier-deck-column-3";
+
+  controls_column.appendChild(draw_all_button);
+  controls_column.appendChild(draw_two_button);
+  controls_column.appendChild(end_round_div);
+
   modifier_container.appendChild(button_div);
+  modifier_container.appendChild(deck_column);
+  modifier_container.appendChild(controls_column);
 
   container.appendChild(modifier_container);
 


### PR DESCRIPTION
## Summary
- isolate modifier deck controls into a new `modifier-deck-column-3`
- style new column to wrap buttons vertically when space is limited
- update draw/shuffle button styles

## Testing
- `bash gen-manifest.sh`

------
https://chatgpt.com/codex/tasks/task_e_68796a1c2bec832398572f76854a53b2