### PR TITLE
Add draw-all row and update modifier deck layout

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -30,23 +30,38 @@
     margin:                     8px;
 }
 
-.modifier-deck-column-1
+.modifier-deck-column-1,
+.modifier-deck-column-2,
+.modifier-deck-column-3
 {
-    float:                      left;
     margin:                     0;
     padding:                    0;
-    width:                      20%;
-    height:                     100%;
+}
+
+#modifier-container
+{
+    display:                    flex;
+    justify-content:            space-between;
+    align-items:                center;
+}
+
+.modifier-deck-column-1
+{
+    flex:                       0 0 20%;
 }
 
 .modifier-deck-column-2
 {
-    float:                      right;
-    margin:                     0;
-    padding:                    0;
-    width:                      100%;
-    margin-left:                -30%;
-    height:                     100%;
+    flex:                       1 1 0;
+}
+
+.modifier-deck-column-3
+{
+    flex:                       0 0 20%;
+    display:                    flex;
+    flex-direction:             column;
+    align-items:                center;
+    justify-content:            center;
 }
 
 .counter-icon
@@ -116,12 +131,9 @@
     background-size:            50%;
     cursor:                     pointer;
 
-    position:                   absolute;
-    right:                      18%;
-    bottom:                     10px;
     width:                      20%;
     height:                     20%;
-    margin: 0;
+    margin:                     0.3em auto;
 }
 
 .shuffle.not-required
@@ -165,9 +177,6 @@
 
 .draw-two.button
 {
-    position:                   absolute;
-    right:                      42%;
-    bottom:                     10px;
     width:                      20%;
     height:                     20%;
     background-repeat:          no-repeat;
@@ -175,26 +184,14 @@
     background-size:            50%;
     background-image:           url(images/draw-two.svg);
     cursor:                     pointer;
+    margin:                     0.3em auto;
 }
 
-.draw-all.button
-{
-    position:                   absolute;
-    right:                      66%;
-    bottom:                     10px;
-    width:                      20%;
-    height:                     20%;
-    background-repeat:          no-repeat;
-    background-position:        center center;
-    background-size:            50%;
-    background-image:           url(images/draw-all.svg);
-    cursor:                     pointer;
-}
 
 .card-container.modifier
 {
-    width:                      70%;
-    float:                      right;
+    width:                      100%;
+    float:                      none;
 }
 
 .card-container::before

--- a/index.html
+++ b/index.html
@@ -81,12 +81,6 @@
     <div id="tableau" style="font-size: 26.6px">
       <!-- base font size for all cards. Placed here to make it adjustable from javascript -->
       <div id="modifier-container" class="card-container">
-        <div class="modifier-deck-column-2">
-          <div id="modifier-deck-space" class="card-container modifier" title="Click to draw one card"></div>
-          <div class="button draw-all" title="Draw all monster cards"></div>
-          <div class="button draw-two" title="Click to draw two cards"></div>
-          <div id="end-round" class="counter-icon shuffle not-required" title="Click to end round and shuffle"></div>
-        </div>
         <div class="modifier-deck-column-1">
           <div id="bless-counter" class="counter-icon" title="Bless cards">
             <div class="background bless"></div>
@@ -101,6 +95,16 @@
             <div class="increment button">+</div>
           </div>
         </div>
+        <div class="modifier-deck-column-2">
+          <div id="modifier-deck-space" class="card-container modifier" title="Click to draw one card"></div>
+        </div>
+        <div class="modifier-deck-column-3">
+          <div class="button draw-two" title="Click to draw two cards"></div>
+          <div id="end-round" class="counter-icon shuffle not-required" title="Click to end round and shuffle"></div>
+        </div>
+      </div>
+      <div id="draw-all-monsters" class="draw-all-row" title="Draw all monster cards">
+        Draw all monster cards
       </div>
     </div>
   </body>

--- a/logic.js
+++ b/logic.js
@@ -1125,7 +1125,7 @@ function add_modifier_deck(container, deck, preserve_discards) {
 
   var deck_space = document.getElementById("modifier-deck-space");
   var draw_two_button = modifier_container.querySelector(".button.draw-two");
-  var draw_all_button = modifier_container.querySelector(".button.draw-all");
+  var draw_all_button = document.getElementById("draw-all-monsters");
   var end_round_div = document.getElementById("end-round");
 
   init_counter(

--- a/style.css
+++ b/style.css
@@ -238,6 +238,19 @@ li.currentdeck a:hover {
     display: block;
 }
 
+/* Draw all monster cards row */
+#draw-all-monsters {
+    flex-basis: 100%;
+    background: #444;
+    border-radius: 4px;
+    padding: 0.3em 0.6em;
+    margin: 0.5em 0;
+    text-align: center;
+    color: white;
+    font-family: 'PirataOne', sans-serif;
+    cursor: pointer;
+}
+
 .monster-stat-block .stats-grid {
     /*
      * Use flexbox as a fallback for legacy browsers that do not support CSS


### PR DESCRIPTION
## Summary
- change modifier deck to use three columns
- add new full-width row to draw all monster cards
- remove old draw-all icon and wire up new row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687995cd8f148323890b1b9f5926fa25