### PR TITLE
Refactor modifier deck to three-column layout

### DIFF
--- a/cards.css
+++ b/cards.css
@@ -30,23 +30,44 @@
     margin:                     8px;
 }
 
+.modifier-deck-column-1,
+.modifier-deck-column-2,
+.modifier-deck-column-3
+{
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+#modifier-container
+{
+    display: flex;
+    align-items: flex-start;
+}
+
 .modifier-deck-column-1
 {
-    float:                      left;
-    margin:                     0;
-    padding:                    0;
-    width:                      20%;
-    height:                     100%;
+    width: 15%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
 .modifier-deck-column-2
 {
-    float:                      right;
-    margin:                     0;
-    padding:                    0;
-    width:                      100%;
-    margin-left:                -30%;
-    height:                     100%;
+    width: 70%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.modifier-deck-column-3
+{
+    width: 15%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .counter-icon
@@ -116,12 +137,10 @@
     background-size:            50%;
     cursor:                     pointer;
 
-    position:                   absolute;
-    right:                      18%;
-    bottom:                     10px;
-    width:                      20%;
+    position:                   static;
+    width:                      100%;
     height:                     20%;
-    margin: 0;
+    margin: 0.3em 0;
 }
 
 .shuffle.not-required
@@ -165,36 +184,34 @@
 
 .draw-two.button
 {
-    position:                   absolute;
-    right:                      42%;
-    bottom:                     10px;
-    width:                      20%;
+    position:                   static;
+    width:                      100%;
     height:                     20%;
     background-repeat:          no-repeat;
     background-position:        center center;
     background-size:            50%;
     background-image:           url(images/draw-two.svg);
     cursor:                     pointer;
+    margin: 0.3em 0;
 }
 
 .draw-all.button
 {
-    position:                   absolute;
-    right:                      66%;
-    bottom:                     10px;
-    width:                      20%;
+    position:                   static;
+    width:                      100%;
     height:                     20%;
     background-repeat:          no-repeat;
     background-position:        center center;
     background-size:            50%;
     background-image:           url(images/draw-all.svg);
     cursor:                     pointer;
+    margin: 0.3em 0;
 }
 
 .card-container.modifier
 {
-    width:                      70%;
-    float:                      right;
+    width:                      100%;
+    float:                      none;
 }
 
 .card-container::before

--- a/cards.css
+++ b/cards.css
@@ -30,6 +30,7 @@
     margin:                     8px;
 }
 
+
 .modifier-deck-column-1,
 .modifier-deck-column-2,
 .modifier-deck-column-3
@@ -73,8 +74,9 @@
 .counter-icon
 {
     position:                   relative;
-    height:                     22%;
-    margin:                     30% 0;
+    height:                     auto;
+    margin:                     1rem 0;
+    min-width: 70px;
 
     list-style:                 none;
 
@@ -212,9 +214,17 @@
 {
     width:                      100%;
     float:                      none;
+    min-height:200px;
 }
 
-.card-container::before
+.card-container.modifier::before
+{
+    content:                    "";
+    visibility:                 hidden;
+    display:                    inline-block;
+}
+
+.card-container.monster::before
 {
     content:                    "";
     visibility:                 hidden;

--- a/index.html
+++ b/index.html
@@ -81,12 +81,6 @@
     <div id="tableau" style="font-size: 26.6px">
       <!-- base font size for all cards. Placed here to make it adjustable from javascript -->
       <div id="modifier-container" class="card-container">
-        <div class="modifier-deck-column-2">
-          <div id="modifier-deck-space" class="card-container modifier" title="Click to draw one card"></div>
-          <div class="button draw-all" title="Draw all monster cards"></div>
-          <div class="button draw-two" title="Click to draw two cards"></div>
-          <div id="end-round" class="counter-icon shuffle not-required" title="Click to end round and shuffle"></div>
-        </div>
         <div class="modifier-deck-column-1">
           <div id="bless-counter" class="counter-icon" title="Bless cards">
             <div class="background bless"></div>
@@ -100,6 +94,14 @@
             <div class="icon-text">0</div>
             <div class="increment button">+</div>
           </div>
+        </div>
+        <div class="modifier-deck-column-2">
+          <div id="modifier-deck-space" class="card-container modifier" title="Click to draw one card"></div>
+        </div>
+        <div class="modifier-deck-column-3">
+          <div class="button draw-all" title="Draw all monster cards"></div>
+          <div class="button draw-two" title="Click to draw two cards"></div>
+          <div id="end-round" class="counter-icon shuffle not-required" title="Click to end round and shuffle"></div>
         </div>
       </div>
     </div>

--- a/logic.js
+++ b/logic.js
@@ -964,7 +964,6 @@ function apply_deck_selection(decks, preserve_existing_deck_state) {
 
   decks_to_remove.forEach(function (deck) {
     deck.discard_deck();
-
   });
   visible_ability_decks.forEach(function (deck) {
     var deckid = deck.get_real_name().replace(/\s+/g, "");
@@ -975,7 +974,6 @@ function apply_deck_selection(decks, preserve_existing_deck_state) {
       stats_container.appendChild(stat_block);
     }
   });
-
 
   decks_to_add.forEach(function (deck) {
     var deckid = deck.get_real_name().replace(/\s+/g, "");
@@ -992,6 +990,7 @@ function apply_deck_selection(decks, preserve_existing_deck_state) {
       false
     );
     deck_space.className = "card-container";
+    deck_space.classList.add("monster");
     deck_space.title = "Click to draw enemy ability";
 
     container.appendChild(deck_space);
@@ -1157,7 +1156,6 @@ function add_modifier_deck(container, deck, preserve_discards) {
   deck_space.onclick = draw_modifier_card.bind(null, deck);
 }
 
-
 function create_stat_block(deck) {
   function stat_line(macro, values) {
     if (macro === "%range%" && values[0] === 0) {
@@ -1250,7 +1248,8 @@ function create_stat_block(deck) {
   var hp = document.createElement("div");
   hp.innerHTML = "HP " + deck.health[0];
   if (deck.health.length > 1 && deck.health[1] > 0) {
-    hp.innerHTML += " / <span class='elite-color'>" + deck.health[1] + "</span>";
+    hp.innerHTML +=
+      " / <span class='elite-color'>" + deck.health[1] + "</span>";
   }
   grid.appendChild(hp);
 
@@ -1261,11 +1260,14 @@ function create_stat_block(deck) {
   var range = icon_stat("range", deck.range, true);
   if (range) grid.appendChild(range);
 
-  if (deck.attributes && (deck.attributes[0].length || deck.attributes[1].length)) {
+  if (
+    deck.attributes &&
+    (deck.attributes[0].length || deck.attributes[1].length)
+  ) {
     var map = {};
-    [0, 1].forEach(function(idx) {
-      deck.attributes[idx].forEach(function(a) {
-        a.split(":").forEach(function(part) {
+    [0, 1].forEach(function (idx) {
+      deck.attributes[idx].forEach(function (a) {
+        a.split(":").forEach(function (part) {
           part = part.trim();
           if (!part) return;
           var m = part.match(/(%[^%]+%)(?:\s*(-?\d+))?/);
@@ -1277,7 +1279,7 @@ function create_stat_block(deck) {
         });
       });
     });
-    Object.keys(map).forEach(function(icon) {
+    Object.keys(map).forEach(function (icon) {
       var div = icon_attr(icon, map[icon][0], map[icon][1]);
       if (div) grid.appendChild(div);
     });


### PR DESCRIPTION
## Summary
- reorganize modifier container HTML to three columns
- convert container to flex layout and adjust deck columns
- position draw and shuffle controls in a new right column

## Testing
- `./gen-manifest.sh`

------
https://chatgpt.com/codex/tasks/task_e_688514d9fd908323bfa260988536d975